### PR TITLE
feat: KaraFun Overlay Improvements and Manual Triggers (#4, #5, #6)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -49,6 +49,11 @@ service cloud.firestore {
         allow read: if request.auth != null;
         allow write: if request.auth != null;
       }
+
+      match /overlay_triggers/{document=**} {
+        allow read: if true;
+        allow write: if request.auth != null && request.auth.uid == userId;
+      }
     }
   }
 }

--- a/src/app/api/overlay/[userId]/route.js
+++ b/src/app/api/overlay/[userId]/route.js
@@ -98,6 +98,20 @@ export async function GET(request, { params }) {
                 await captureEvent(posthogClient, userId, 'api_overlay_success', { action: action, userId: userId, message_hidden: true }, true);
                 return NextResponse.json({ success: true, action: action, message_hidden: true });
             }
+            case 'show-now-playing': {
+                // Manually trigger the Now Playing popup by writing a trigger document
+                const triggerRef = adminDb.collection('users').doc(userId).collection('overlay_triggers').doc('now_playing');
+                await triggerRef.set({ triggeredAt: new Date().toISOString() });
+                await captureEvent(posthogClient, userId, 'api_overlay_success', { action: action, userId: userId }, true);
+                return NextResponse.json({ success: true, action: action });
+            }
+            case 'hide-now-playing': {
+                // Manually dismiss the Now Playing popup
+                const triggerRef = adminDb.collection('users').doc(userId).collection('overlay_triggers').doc('now_playing');
+                await triggerRef.delete();
+                await captureEvent(posthogClient, userId, 'api_overlay_success', { action: action, userId: userId }, true);
+                return NextResponse.json({ success: true, action: action });
+            }
             default:
                 const errorMsg = "Invalid action";
                 await captureEvent(posthogClient, userId, 'api_overlay_error', { error: errorMsg, status: 400, action: action, userId: userId }, true);

--- a/src/app/overlay/[userId]/page.js
+++ b/src/app/overlay/[userId]/page.js
@@ -143,9 +143,9 @@ export default function OverlayPage() {
 
                     // Only show if it's NOT stale (or if it's the first one we ever seen and it happens to be fresh)
                     if (!isStale) {
-                        setShowNowPlaying(true);
+                        const timer = setTimeout(() => setShowNowPlaying(true), 0);
                         if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
-                        hideTimerRef.current = setTimeout(() => setShowNowPlaying(false), 10000);
+                        hideTimerRef.current = setTimeout(() => setShowNowPlaying(false), 5000);
                     } else if (wasStaleOnLoad) {
                         console.log("[Trigger] Ignoring stale manual trigger on page load");
                     }
@@ -310,13 +310,13 @@ export default function OverlayPage() {
             // Clear any existing hide timer
             if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
 
-            // Pop showing immediately
-            setShowNowPlaying(true);
+            // Pop showing with a small delay to avoid cascading render lint error
+            const timer = setTimeout(() => setShowNowPlaying(true), 0);
 
             // Arm the shared hide timer
             hideTimerRef.current = setTimeout(() => {
                 setShowNowPlaying(false);
-            }, 10000);
+            }, 5000);
         }
     }, [karafunNowPlaying, karafunPlayState, settings.karafunOverlayNowPlayingEnabled, hideTimerRef]);
 

--- a/src/app/overlay/[userId]/page.js
+++ b/src/app/overlay/[userId]/page.js
@@ -292,8 +292,8 @@ export default function OverlayPage() {
 
         // 1. If playback stops or nothing is playing, hide immediately
         if (!isPlaying || !karafunNowPlaying) {
-            setShowNowPlaying(false);
-            return;
+            const timer = setTimeout(() => setShowNowPlaying(false), 0);
+            return () => clearTimeout(timer);
         }
 
         // 2. Trigger on:

--- a/src/app/overlay/[userId]/page.js
+++ b/src/app/overlay/[userId]/page.js
@@ -250,8 +250,8 @@ export default function OverlayPage() {
                 setKarafunQueue([]);
                 return;
             }
-            const transformed = items.map(item => ({
-                id: item.queueId || item.songId || `${item.title}-${item.artist}`,
+            const transformed = items.map((item, idx) => ({
+                id: item.queueId || item.songId || `${item.title}-${item.artist}-${idx}`,
                 title: item.title || 'Unknown',
                 artist: item.artist || '',
                 singer: item.singer || '',
@@ -281,24 +281,24 @@ export default function OverlayPage() {
 
     // Trigger Now Playing animation ONLY when a genuinely new song starts playing.
     useEffect(() => {
-        if (!settings.karafunOverlayNowPlayingEnabled || !karafunNowPlaying) return;
+        if (!settings.karafunOverlayNowPlayingEnabled) return;
 
-        const songKey = `${karafunNowPlaying.title}-${karafunNowPlaying.artist}`.trim().toLowerCase();
+        const songKey = karafunNowPlaying ? `${karafunNowPlaying.title}-${karafunNowPlaying.artist}`.trim().toLowerCase() : '';
         const isPlaying = karafunPlayState === 'playing';
         const prevWasPlaying = lastPlayStateRef.current === 'playing';
+
+        // Update play state ref immediately to track transitions correctly in the next run
         lastPlayStateRef.current = karafunPlayState;
 
-        // Skip logic if we're not currently in a 'playing' state
-        if (!isPlaying) {
-            // If playback stops, we can hide immediately, but we keep the lastTriggeredSong
-            // intact so if it resumes it doesn't trigger again unless it's a new song.
-            const hideTimer = setTimeout(() => setShowNowPlaying(false), 0);
-            return () => clearTimeout(hideTimer);
+        // 1. If playback stops or nothing is playing, hide immediately
+        if (!isPlaying || !karafunNowPlaying) {
+            setShowNowPlaying(false);
+            return;
         }
 
-        // Trigger on:
-        // 1. Title/Artist change while playing
-        // 2. Playback RESUMED from a non-playing state (stop/infoscreen)
+        // 2. Trigger on:
+        // - Title/Artist change while playing
+        // - Playback RESUMED from a non-playing state (stop/infoscreen)
         const hasSongChanged = songKey !== lastTriggeredSongRef.current;
         const hasBecomePlaying = isPlaying && !prevWasPlaying;
 
@@ -312,6 +312,7 @@ export default function OverlayPage() {
             const hideTimer = setTimeout(() => {
                 setShowNowPlaying(false);
             }, 10000);
+
             return () => {
                 clearTimeout(popupTimer);
                 clearTimeout(hideTimer);

--- a/src/app/overlay/[userId]/page.js
+++ b/src/app/overlay/[userId]/page.js
@@ -298,29 +298,29 @@ export default function OverlayPage() {
             case 'future':
                 return {
                     ...baseStyles,
-                    card: "bg-[#0b1622]/85 backdrop-blur-md border border-[#1271ff]/40 p-4 shadow-[0_0_30px_rgba(18,113,255,0.2)]",
+                    card: "bg-[#0b1622]/90 backdrop-blur-md border border-[#1271ff]/40 p-4 shadow-[0_0_30px_rgba(18,113,255,0.2)]",
                     highlight: "bg-[#1271ff]/20 border border-[#1271ff]",
                     textPrimary: "font-black text-white",
-                    textSecondary: "text-[#1271ff] text-sm",
-                    textTertiary: "text-blue-300/60 text-xs",
+                    textSecondary: "text-[#7db8ff] text-sm",
+                    textTertiary: "text-blue-200/80 text-xs",
                 };
             case 'glass':
                 return {
                     ...baseStyles,
-                    card: "bg-black/40 backdrop-blur-xl border border-white/20 p-4 rounded-[20px]",
+                    card: "bg-black/60 backdrop-blur-xl border border-white/20 p-4 rounded-[20px]",
                     highlight: "bg-white/10 border-white/40",
                     textPrimary: "font-bold text-white",
-                    textSecondary: "text-zinc-300 text-sm",
-                    textTertiary: "text-zinc-400 text-xs",
+                    textSecondary: "text-zinc-100 text-sm",
+                    textTertiary: "text-zinc-200 text-xs",
                 };
             case 'neon':
                 return {
                     ...baseStyles,
-                    card: "bg-black/80 border border-white/10 p-4 shadow-[0_0_15px_#9146FF] rounded-xl",
+                    card: "bg-black/85 border border-white/10 p-4 shadow-[0_0_15px_#9146FF] rounded-xl",
                     highlight: "bg-[#9146FF] shadow-[0_0_10px_#9146FF]",
                     textPrimary: "font-black text-white",
-                    textSecondary: "text-[#d7b8ff] text-sm",
-                    textTertiary: "text-zinc-400 text-xs",
+                    textSecondary: "text-[#e8d4ff] text-sm",
+                    textTertiary: "text-zinc-200 text-xs",
                 };
             case 'minimal':
                 return {
@@ -328,8 +328,8 @@ export default function OverlayPage() {
                     card: "bg-black/90 p-4 rounded-lg",
                     highlight: "border-l-4 border-white pl-4",
                     textPrimary: "font-medium text-white",
-                    textSecondary: "text-zinc-400 text-sm",
-                    textTertiary: "text-zinc-500 text-xs",
+                    textSecondary: "text-zinc-200 text-sm",
+                    textTertiary: "text-zinc-300 text-xs",
                 };
             case 'bold':
                 return {
@@ -344,11 +344,11 @@ export default function OverlayPage() {
             default:
                 return {
                     ...baseStyles,
-                    card: "bg-black/60 backdrop-blur-md border border-white/5 p-4 rounded-xl",
+                    card: "bg-black/80 backdrop-blur-md border border-white/10 p-4 rounded-xl",
                     highlight: "bg-white/10",
                     textPrimary: "font-bold text-white",
-                    textSecondary: "text-zinc-300 text-sm",
-                    textTertiary: "text-zinc-400 text-xs",
+                    textSecondary: "text-zinc-100 text-sm",
+                    textTertiary: "text-zinc-200 text-xs",
                 };
         }
     };
@@ -634,38 +634,52 @@ export default function OverlayPage() {
             </AnimatePresence>
 
             {/* KaraFun Overlays */}
-            {settings.karafunOverlayQueueEnabled && karafunQueue.length > 0 && (
-                <div
-                    className={getKaraFunThemeStyles().queueContainer}
-                    style={{
-                        left: `${settings.karafunQueuePosX ?? 5}%`,
-                        top: `${settings.karafunQueuePosY ?? 5}%`,
-                        transform: `translate(${(settings.karafunQueuePosX ?? 5) > 50 ? '-100%' : '0%'}, ${(settings.karafunQueuePosY ?? 5) > 50 ? '-100%' : '0%'})`,
-                        fontFamily: settings.karafunFontFamily ? `'${settings.karafunFontFamily}', sans-serif` : 'inherit',
-                        color: settings.karafunTextColor || undefined
-                    }}
-                >
-                    <div className={`${getKaraFunThemeStyles().card} rounded-t-2xl font-black text-xs uppercase tracking-widest text-zinc-500 z-0`}>
-                        <ListMusic className="inline-block w-4 h-4 mr-2" /> Song Queue
-                    </div>
-                    {karafunQueue.map((song, i) => {
-                        const isNext = i === 0;
-                        const theme = getKaraFunThemeStyles();
-                        return (
-                            <div key={i} className={`${theme.card} relative z-10 flex flex-col gap-1 transition-all ${isNext ? theme.highlight : ''}`}>
-                                {isNext && <span className="absolute -top-3 left-4 bg-pink-500 text-white text-[10px] font-black uppercase px-2 py-0.5 rounded-full shadow-lg">Next Up</span>}
-                                <div className={theme.textPrimary}>{song.title}</div>
-                                <div className={theme.textSecondary}>{song.artist}</div>
-                                {song.singer && (
-                                    <div className={`mt-1 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md w-max ${theme.textTertiary} bg-white/5`}>
-                                        <User size={12} /> {song.singer}
-                                    </div>
-                                )}
-                            </div>
-                        );
-                    })}
-                </div>
-            )}
+            <AnimatePresence>
+                {settings.karafunOverlayQueueEnabled && karafunQueue.length > 0 && (
+                    <motion.div
+                        key="karafun-queue"
+                        initial={{ opacity: 0, x: -60 }}
+                        animate={{ opacity: 1, x: 0, transition: { duration: 0.5, ease: 'easeOut' } }}
+                        exit={{ opacity: 0, x: -60, transition: { duration: 0.4, ease: 'easeIn' } }}
+                        className={getKaraFunThemeStyles().queueContainer}
+                        style={{
+                            left: `${settings.karafunQueuePosX ?? 5}%`,
+                            top: `${settings.karafunQueuePosY ?? 5}%`,
+                            transform: `translate(${(settings.karafunQueuePosX ?? 5) > 50 ? '-100%' : '0%'}, ${(settings.karafunQueuePosY ?? 5) > 50 ? '-100%' : '0%'})`,
+                            fontFamily: settings.karafunFontFamily ? `'${settings.karafunFontFamily}', sans-serif` : 'inherit',
+                            color: settings.karafunTextColor || undefined
+                        }}
+                    >
+                        <div className={`${getKaraFunThemeStyles().card} rounded-t-2xl font-black text-xs uppercase tracking-widest text-zinc-200 z-0 drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)]`}>
+                            <ListMusic className="inline-block w-4 h-4 mr-2" /> Song Queue
+                        </div>
+                        <AnimatePresence>
+                            {karafunQueue.map((song, i) => {
+                                const isNext = i === 0;
+                                const theme = getKaraFunThemeStyles();
+                                return (
+                                    <motion.div
+                                        key={song.title + i}
+                                        initial={{ opacity: 0, y: -20 }}
+                                        animate={{ opacity: 1, y: 0, transition: { duration: 0.35, delay: i * 0.07, ease: 'easeOut' } }}
+                                        exit={{ opacity: 0, y: -10, transition: { duration: 0.25 } }}
+                                        className={`${theme.card} relative z-10 flex flex-col gap-1 transition-all ${isNext ? theme.highlight : ''}`}
+                                    >
+                                        {isNext && <span className="absolute -top-3 left-4 bg-pink-500 text-white text-[10px] font-black uppercase px-2 py-0.5 rounded-full shadow-lg">Next Up</span>}
+                                        <div className={`${theme.textPrimary} drop-shadow-[0_1px_4px_rgba(0,0,0,1)]`}>{song.title}</div>
+                                        <div className={`${theme.textSecondary} drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)]`}>{song.artist}</div>
+                                        {song.singer && (
+                                            <div className={`mt-1 inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md w-max ${theme.textTertiary} bg-white/10 drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]`}>
+                                                <User size={12} /> {song.singer}
+                                            </div>
+                                        )}
+                                    </motion.div>
+                                );
+                            })}
+                        </AnimatePresence>
+                    </motion.div>
+                )}
+            </AnimatePresence>
 
             <AnimatePresence>
                 {settings.karafunOverlayNowPlayingEnabled && showNowPlaying && karafunNowPlaying && (
@@ -686,13 +700,13 @@ export default function OverlayPage() {
                             Now Playing
                         </div>
                         <div className={`${getKaraFunThemeStyles().card} !pb-6 !pt-8 !px-8 min-w-[400px] text-center flex flex-col items-center gap-2`}>
-                            <h2 className={`${getKaraFunThemeStyles().textPrimary} text-4xl mb-1`}>{karafunNowPlaying.title}</h2>
-                            <p className={`${getKaraFunThemeStyles().textSecondary} text-xl`}>{karafunNowPlaying.artist}</p>
+                            <h2 className={`${getKaraFunThemeStyles().textPrimary} text-4xl mb-1 drop-shadow-[0_2px_6px_rgba(0,0,0,1)]`}>{karafunNowPlaying.title}</h2>
+                            <p className={`${getKaraFunThemeStyles().textSecondary} text-xl drop-shadow-[0_1px_4px_rgba(0,0,0,0.9)]`}>{karafunNowPlaying.artist}</p>
                             {karafunNowPlaying.singer && (
-                                <div className="mt-4 bg-white/10 p-3 rounded-xl flex items-center justify-center gap-3 w-full">
+                                <div className="mt-4 bg-white/15 p-3 rounded-xl flex items-center justify-center gap-3 w-full">
                                     <User size={18} className="text-pink-400" />
-                                    <span className={`${getKaraFunThemeStyles().textTertiary} !text-base font-bold text-white`}>
-                                        Sung by <span className="text-pink-400">{karafunNowPlaying.singer}</span>
+                                    <span className={`${getKaraFunThemeStyles().textTertiary} !text-base font-bold text-white drop-shadow-[0_1px_3px_rgba(0,0,0,0.9)]`}>
+                                        Sung by <span className="text-pink-300 font-black">{karafunNowPlaying.singer}</span>
                                     </span>
                                 </div>
                             )}

--- a/src/app/overlay/[userId]/page.js
+++ b/src/app/overlay/[userId]/page.js
@@ -35,6 +35,8 @@ export default function OverlayPage() {
     const [karafunNowPlaying, setKarafunNowPlaying] = useState(null);
     const [karafunPlayState, setKarafunPlayState] = useState('stop');
     const [showNowPlaying, setShowNowPlaying] = useState(false);
+    // Track the last song title+state that triggered the popup so we only fire on genuine song starts
+    const lastTriggeredSongRef = useRef(null);
 
     const [settings, setSettings] = useState({
         textColor: '#ffffff',
@@ -119,6 +121,31 @@ export default function OverlayPage() {
         });
         return () => { unsubscribeSettings(); unsubscribeMessage(); };
     }, [userId, processedIds]);
+
+    // Listen for manual "show now playing" triggers written via the API
+    useEffect(() => {
+        if (!userId) return;
+        const triggerRef = doc(db, 'users', userId, 'overlay_triggers', 'now_playing');
+        let hideTimeout = null;
+        const unsubscribeTrigger = onSnapshot(triggerRef, (snap) => {
+            if (snap.exists()) {
+                // Manual trigger: show the popup and reset the song key guard so
+                // the next automatic KaraFun start still fires as expected
+                lastTriggeredSongRef.current = null;
+                setShowNowPlaying(true);
+                if (hideTimeout) clearTimeout(hideTimeout);
+                hideTimeout = setTimeout(() => setShowNowPlaying(false), 10000);
+            } else {
+                // Document deleted → hide-now-playing called
+                if (hideTimeout) clearTimeout(hideTimeout);
+                setShowNowPlaying(false);
+            }
+        });
+        return () => {
+            unsubscribeTrigger();
+            if (hideTimeout) clearTimeout(hideTimeout);
+        };
+    }, [userId]);
 
     const processNextMessage = useCallback(async () => {
         setIsProcessing(true);
@@ -237,25 +264,35 @@ export default function OverlayPage() {
         };
     }, [settings.karafunEnabled, settings.karafunOverlayQueueEnabled, settings.karafunOverlayNowPlayingEnabled, settings.karafunPartyId]);
 
-    // Trigger Now Playing animation when a new song starts
+    // Trigger Now Playing animation ONLY when a genuinely new song starts playing.
+    // We key on the song title changing OR the state transitioning into 'playing'.
+    // Queue operations (volume, pitch, reorder) that fire a status event but don't
+    // change the song title are intentionally ignored.
     useEffect(() => {
-        if (settings.karafunOverlayNowPlayingEnabled && karafunPlayState === 'playing' && karafunNowPlaying) {
-            // Use setTimeout to avoid synchronous setState inside an effect (lint fix)
+        if (!settings.karafunOverlayNowPlayingEnabled || !karafunNowPlaying) return;
+
+        const songKey = karafunNowPlaying.title;
+        const isPlaying = karafunPlayState === 'playing';
+
+        // Only show popup when the song is playing AND it's a different song from the last trigger
+        if (isPlaying && songKey !== lastTriggeredSongRef.current) {
+            lastTriggeredSongRef.current = songKey;
+
             const popupTimer = setTimeout(() => {
                 setShowNowPlaying(true);
             }, 0);
-
-            const timer = setTimeout(() => {
-                setShowNowPlaying(false);
-            }, 10000); // Show for 10 seconds
-            return () => {
-                clearTimeout(popupTimer);
-                clearTimeout(timer);
-            };
-        } else {
             const hideTimer = setTimeout(() => {
                 setShowNowPlaying(false);
-            }, 0);
+            }, 10000);
+            return () => {
+                clearTimeout(popupTimer);
+                clearTimeout(hideTimer);
+            };
+        }
+
+        // If playback stops, hide immediately
+        if (!isPlaying) {
+            const hideTimer = setTimeout(() => setShowNowPlaying(false), 0);
             return () => clearTimeout(hideTimer);
         }
     }, [karafunNowPlaying, karafunPlayState, settings.karafunOverlayNowPlayingEnabled]);

--- a/src/app/overlay/[userId]/page.js
+++ b/src/app/overlay/[userId]/page.js
@@ -37,6 +37,7 @@ export default function OverlayPage() {
     const [showNowPlaying, setShowNowPlaying] = useState(false);
     // Track the last song title+state that triggered the popup so we only fire on genuine song starts
     const lastTriggeredSongRef = useRef(null);
+    const lastPlayStateRef = useRef(null);
 
     const [settings, setSettings] = useState({
         textColor: '#ffffff',
@@ -129,14 +130,13 @@ export default function OverlayPage() {
         let hideTimeout = null;
         const unsubscribeTrigger = onSnapshot(triggerRef, (snap) => {
             if (snap.exists()) {
-                // Manual trigger: show the popup and reset the song key guard so
-                // the next automatic KaraFun start still fires as expected
-                lastTriggeredSongRef.current = null;
+                // Manual override: show the popup immediately. 
+                // We DON'T reset lastTriggeredSongRef here to avoid the automatic trigger 
+                // refiring on the next socket update while the song is still the same.
                 setShowNowPlaying(true);
                 if (hideTimeout) clearTimeout(hideTimeout);
                 hideTimeout = setTimeout(() => setShowNowPlaying(false), 10000);
             } else {
-                // Document deleted → hide-now-playing called
                 if (hideTimeout) clearTimeout(hideTimeout);
                 setShowNowPlaying(false);
             }
@@ -265,17 +265,30 @@ export default function OverlayPage() {
     }, [settings.karafunEnabled, settings.karafunOverlayQueueEnabled, settings.karafunOverlayNowPlayingEnabled, settings.karafunPartyId]);
 
     // Trigger Now Playing animation ONLY when a genuinely new song starts playing.
-    // We key on the song title changing OR the state transitioning into 'playing'.
-    // Queue operations (volume, pitch, reorder) that fire a status event but don't
-    // change the song title are intentionally ignored.
     useEffect(() => {
         if (!settings.karafunOverlayNowPlayingEnabled || !karafunNowPlaying) return;
 
-        const songKey = karafunNowPlaying.title;
+        const songKey = `${karafunNowPlaying.title}-${karafunNowPlaying.artist}`.trim().toLowerCase();
         const isPlaying = karafunPlayState === 'playing';
+        const prevWasPlaying = lastPlayStateRef.current === 'playing';
+        lastPlayStateRef.current = karafunPlayState;
 
-        // Only show popup when the song is playing AND it's a different song from the last trigger
-        if (isPlaying && songKey !== lastTriggeredSongRef.current) {
+        // Skip logic if we're not currently in a 'playing' state
+        if (!isPlaying) {
+            // If playback stops, we can hide immediately, but we keep the lastTriggeredSong
+            // intact so if it resumes it doesn't trigger again unless it's a new song.
+            const hideTimer = setTimeout(() => setShowNowPlaying(false), 0);
+            return () => clearTimeout(hideTimer);
+        }
+
+        // Trigger on:
+        // 1. Title/Artist change while playing
+        // 2. Playback RESUMED from a non-playing state (stop/infoscreen)
+        const hasSongChanged = songKey !== lastTriggeredSongRef.current;
+        const hasBecomePlaying = isPlaying && !prevWasPlaying;
+
+        if (hasSongChanged || hasBecomePlaying) {
+            console.log(`[NowPlaying] Triggered: ${songKey} (Changed: ${hasSongChanged}, Resumed: ${hasBecomePlaying})`);
             lastTriggeredSongRef.current = songKey;
 
             const popupTimer = setTimeout(() => {
@@ -288,12 +301,6 @@ export default function OverlayPage() {
                 clearTimeout(popupTimer);
                 clearTimeout(hideTimer);
             };
-        }
-
-        // If playback stops, hide immediately
-        if (!isPlaying) {
-            const hideTimer = setTimeout(() => setShowNowPlaying(false), 0);
-            return () => clearTimeout(hideTimer);
         }
     }, [karafunNowPlaying, karafunPlayState, settings.karafunOverlayNowPlayingEnabled]);
 

--- a/src/app/overlay/[userId]/page.js
+++ b/src/app/overlay/[userId]/page.js
@@ -133,13 +133,22 @@ export default function OverlayPage() {
             if (snap.exists()) {
                 const data = snap.data();
                 const triggerTime = data.triggeredAt ? new Date(data.triggeredAt).getTime() : 0;
+                const now = Date.now();
+                const isStale = (now - triggerTime) > 10000;
 
-                // Only show if the trigger is NEWER than our last handled trigger
+                // Update ref immediately to prevent replaying this specific trigger doc later
                 if (triggerTime > lastManualTriggerRef.current) {
+                    const wasStaleOnLoad = lastManualTriggerRef.current === 0 && isStale;
                     lastManualTriggerRef.current = triggerTime;
-                    setShowNowPlaying(true);
-                    if (hideTimeout) clearTimeout(hideTimeout);
-                    hideTimeout = setTimeout(() => setShowNowPlaying(false), 10000);
+
+                    // Only show if it's NOT stale (or if it's the first one we ever seen and it happens to be fresh)
+                    if (!isStale) {
+                        setShowNowPlaying(true);
+                        if (hideTimeout) clearTimeout(hideTimeout);
+                        hideTimeout = setTimeout(() => setShowNowPlaying(false), 10000);
+                    } else if (wasStaleOnLoad) {
+                        console.log("[Trigger] Ignoring stale manual trigger on page load");
+                    }
                 }
             } else {
                 if (hideTimeout) clearTimeout(hideTimeout);
@@ -242,6 +251,7 @@ export default function OverlayPage() {
                 return;
             }
             const transformed = items.map(item => ({
+                id: item.queueId || item.songId || `${item.title}-${item.artist}`,
                 title: item.title || 'Unknown',
                 artist: item.artist || '',
                 singer: item.singer || '',
@@ -708,7 +718,7 @@ export default function OverlayPage() {
                                 const theme = getKaraFunThemeStyles();
                                 return (
                                     <motion.div
-                                        key={song.title + i}
+                                        key={song.id}
                                         initial={{ opacity: 0, y: -20 }}
                                         animate={{ opacity: 1, y: 0, transition: { duration: 0.35, delay: i * 0.07, ease: 'easeOut' } }}
                                         exit={{ opacity: 0, y: -10, transition: { duration: 0.25 } }}

--- a/src/app/overlay/[userId]/page.js
+++ b/src/app/overlay/[userId]/page.js
@@ -39,6 +39,7 @@ export default function OverlayPage() {
     const lastTriggeredSongRef = useRef(null);
     const lastPlayStateRef = useRef(null);
     const lastManualTriggerRef = useRef(0); // Store timestamp of last manual trigger
+    const hideTimerRef = useRef(null); // Consolidated Ref for auto-hiding the "Now Playing" popup
 
     const [settings, setSettings] = useState({
         textColor: '#ffffff',
@@ -128,7 +129,6 @@ export default function OverlayPage() {
     useEffect(() => {
         if (!userId) return;
         const triggerRef = doc(db, 'users', userId, 'overlay_triggers', 'now_playing');
-        let hideTimeout = null;
         const unsubscribeTrigger = onSnapshot(triggerRef, (snap) => {
             if (snap.exists()) {
                 const data = snap.data();
@@ -144,20 +144,20 @@ export default function OverlayPage() {
                     // Only show if it's NOT stale (or if it's the first one we ever seen and it happens to be fresh)
                     if (!isStale) {
                         setShowNowPlaying(true);
-                        if (hideTimeout) clearTimeout(hideTimeout);
-                        hideTimeout = setTimeout(() => setShowNowPlaying(false), 10000);
+                        if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+                        hideTimerRef.current = setTimeout(() => setShowNowPlaying(false), 10000);
                     } else if (wasStaleOnLoad) {
                         console.log("[Trigger] Ignoring stale manual trigger on page load");
                     }
                 }
             } else {
-                if (hideTimeout) clearTimeout(hideTimeout);
+                if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
                 setShowNowPlaying(false);
             }
         });
         return () => {
             unsubscribeTrigger();
-            if (hideTimeout) clearTimeout(hideTimeout);
+            if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
         };
     }, [userId]);
 
@@ -292,8 +292,9 @@ export default function OverlayPage() {
 
         // 1. If playback stops or nothing is playing, hide immediately
         if (!isPlaying || !karafunNowPlaying) {
-            const timer = setTimeout(() => setShowNowPlaying(false), 0);
-            return () => clearTimeout(timer);
+            if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+            hideTimerRef.current = setTimeout(() => setShowNowPlaying(false), 0);
+            return;
         }
 
         // 2. Trigger on:
@@ -306,19 +307,18 @@ export default function OverlayPage() {
             console.log(`[NowPlaying] Triggered: ${songKey} (Changed: ${hasSongChanged}, Resumed: ${hasBecomePlaying})`);
             lastTriggeredSongRef.current = songKey;
 
-            const popupTimer = setTimeout(() => {
-                setShowNowPlaying(true);
-            }, 0);
-            const hideTimer = setTimeout(() => {
+            // Clear any existing hide timer
+            if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+
+            // Pop showing immediately
+            setShowNowPlaying(true);
+
+            // Arm the shared hide timer
+            hideTimerRef.current = setTimeout(() => {
                 setShowNowPlaying(false);
             }, 10000);
-
-            return () => {
-                clearTimeout(popupTimer);
-                clearTimeout(hideTimer);
-            };
         }
-    }, [karafunNowPlaying, karafunPlayState, settings.karafunOverlayNowPlayingEnabled]);
+    }, [karafunNowPlaying, karafunPlayState, settings.karafunOverlayNowPlayingEnabled, hideTimerRef]);
 
     const getKaraFunThemeStyles = () => {
         const theme = settings.karafunOverlayTheme || 'classic';

--- a/src/app/overlay/[userId]/page.js
+++ b/src/app/overlay/[userId]/page.js
@@ -38,6 +38,7 @@ export default function OverlayPage() {
     // Track the last song title+state that triggered the popup so we only fire on genuine song starts
     const lastTriggeredSongRef = useRef(null);
     const lastPlayStateRef = useRef(null);
+    const lastManualTriggerRef = useRef(0); // Store timestamp of last manual trigger
 
     const [settings, setSettings] = useState({
         textColor: '#ffffff',
@@ -130,12 +131,16 @@ export default function OverlayPage() {
         let hideTimeout = null;
         const unsubscribeTrigger = onSnapshot(triggerRef, (snap) => {
             if (snap.exists()) {
-                // Manual override: show the popup immediately. 
-                // We DON'T reset lastTriggeredSongRef here to avoid the automatic trigger 
-                // refiring on the next socket update while the song is still the same.
-                setShowNowPlaying(true);
-                if (hideTimeout) clearTimeout(hideTimeout);
-                hideTimeout = setTimeout(() => setShowNowPlaying(false), 10000);
+                const data = snap.data();
+                const triggerTime = data.triggeredAt ? new Date(data.triggeredAt).getTime() : 0;
+
+                // Only show if the trigger is NEWER than our last handled trigger
+                if (triggerTime > lastManualTriggerRef.current) {
+                    lastManualTriggerRef.current = triggerTime;
+                    setShowNowPlaying(true);
+                    if (hideTimeout) clearTimeout(hideTimeout);
+                    hideTimeout = setTimeout(() => setShowNowPlaying(false), 10000);
+                }
             } else {
                 if (hideTimeout) clearTimeout(hideTimeout);
                 setShowNowPlaying(false);

--- a/src/components/dashboard/ApiSettings.js
+++ b/src/components/dashboard/ApiSettings.js
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { Terminal, Key, RefreshCw, Power, EyeOff, Check, Copy, AlertTriangle, Link as LinkIcon } from 'lucide-react';
+import { Terminal, Key, RefreshCw, Power, EyeOff, Check, Copy, AlertTriangle, Link as LinkIcon, Play } from 'lucide-react';
 import { db } from '@/lib/firebase';
 import { doc, setDoc } from 'firebase/firestore';
 
@@ -224,6 +224,24 @@ export default function ApiSettings({ targetUid, user, privateConfig, setPrivate
                                 onClick={() => copyApiCommand('now-playing-off')}
                                 copied={copyState === 'api-now-playing-off'}
                             />
+                            <div className="border-t border-zinc-800 pt-3 mt-1 space-y-3">
+                                <p className="text-[10px] font-bold text-zinc-600 uppercase tracking-widest">One-shot Triggers</p>
+                                <EndpointButton
+                                    label="Show Now Playing"
+                                    description="Immediately displays the Now Playing popup for 10 seconds, regardless of KaraFun state."
+                                    icon={<Play size={18} className="text-green-400" />}
+                                    onClick={() => copyApiCommand('show-now-playing')}
+                                    copied={copyState === 'api-show-now-playing'}
+                                />
+                                <EndpointButton
+                                    label="Dismiss Now Playing"
+                                    description="Immediately hides the manually triggered Now Playing popup."
+                                    icon={<EyeOff size={18} className="text-rose-400" />}
+                                    onClick={() => copyApiCommand('hide-now-playing')}
+                                    copied={copyState === 'api-hide-now-playing'}
+                                    isDestructive
+                                />
+                            </div>
                         </div>
                     </div>
 

--- a/src/components/dashboard/KaraFun.js
+++ b/src/components/dashboard/KaraFun.js
@@ -1,14 +1,14 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { Music, RefreshCw, AlertCircle, Play, ListMusic, User, Save, Monitor, Type, Move } from 'lucide-react';
+import { Music, RefreshCw, AlertCircle, Play, ListMusic, User, Save, Monitor, Type, Move, Eye, EyeOff } from 'lucide-react';
 
 const FONTS = [
     'Inter', 'Roboto', 'Poppins', 'Montserrat', 'Oswald',
     'Ubuntu', 'Raleway', 'Playfair Display', 'Bangers', 'Pacifico', 'Monoton'
 ];
 import { db } from '@/lib/firebase';
-import { doc, updateDoc } from 'firebase/firestore';
+import { doc, updateDoc, setDoc, deleteDoc } from 'firebase/firestore';
 import io from 'socket.io-client';
 
 export default function KaraFun({ targetUid, userSettings }) {
@@ -54,6 +54,26 @@ export default function KaraFun({ targetUid, userSettings }) {
             await updateDoc(configRef, { [field]: value });
         } catch (err) {
             console.error(`Error saving ${field}:`, err);
+        }
+    };
+
+    const handleShowNowPlaying = async () => {
+        if (!targetUid) return;
+        try {
+            const triggerRef = doc(db, 'users', targetUid, 'overlay_triggers', 'now_playing');
+            await setDoc(triggerRef, { triggeredAt: new Date().toISOString() });
+        } catch (err) {
+            console.error('Error triggering Now Playing:', err);
+        }
+    };
+
+    const handleHideNowPlaying = async () => {
+        if (!targetUid) return;
+        try {
+            const triggerRef = doc(db, 'users', targetUid, 'overlay_triggers', 'now_playing');
+            await deleteDoc(triggerRef);
+        } catch (err) {
+            console.error('Error hiding Now Playing:', err);
         }
     };
 
@@ -244,9 +264,27 @@ export default function KaraFun({ targetUid, userSettings }) {
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
                     {/* Now Playing */}
                     <div className="space-y-4">
-                        <h4 className="text-[10px] font-black uppercase tracking-[0.2em] text-zinc-500 flex items-center gap-2">
-                            <Play size={12} className="text-green-500" /> Now Playing
-                        </h4>
+                        <div className="flex items-center justify-between">
+                            <h4 className="text-[10px] font-black uppercase tracking-[0.2em] text-zinc-500 flex items-center gap-2">
+                                <Play size={12} className="text-green-500" /> Now Playing
+                            </h4>
+                            <div className="flex items-center gap-2">
+                                <button
+                                    onClick={handleShowNowPlaying}
+                                    title="Manually trigger the Now Playing popup on the overlay"
+                                    className="flex items-center gap-1.5 px-3 py-1.5 bg-green-500/10 hover:bg-green-500/20 text-green-400 border border-green-500/20 rounded-lg text-xs font-bold transition-all active:scale-95"
+                                >
+                                    <Eye size={13} /> Show
+                                </button>
+                                <button
+                                    onClick={handleHideNowPlaying}
+                                    title="Dismiss the Now Playing popup immediately"
+                                    className="flex items-center gap-1.5 px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 border border-red-500/20 rounded-lg text-xs font-bold transition-all active:scale-95"
+                                >
+                                    <EyeOff size={13} /> Dismiss
+                                </button>
+                            </div>
+                        </div>
 
                         {queueData.currentSong ? (
                             <div className="bg-zinc-900 border border-zinc-800 p-6 rounded-3xl relative overflow-hidden group">


### PR DESCRIPTION
## Overview
This PR addresses several issues related to the KaraFun overlay and introduces manual trigger capabilities.

## Changes
### KaraFun Overlay
- **Fix Issue #4**: Resolved \"Now Playing\" overlay triggering on any queue change. Implemented a robust transition-based guard and normalized song identity check (Title + Artist) to ignore volume/queue reorders.
- **Fix Issue #5**: Added entry/exit animations and delay-staggered list animations using `framer-motion`.
- **Fix Issue #6**: Improved text legibility on all themes with better drop shadows, enhanced contrast, and custom background bubbles.
- **Manual Triggers**: Added the ability to manually \"Show\" or \"Dismiss\" the Now Playing popup via the Dashboard and new API endpoints.

### API & Internal
- Added manual trigger Firestore listeners to the overlay page.
- Isolated PostHog server-side events to prevent telemetry failures from breaking API responses.
- Consolidated error handling in API routes to prevent internal detail leaks.
- Extracted PostHog to `src/lib/posthog-server.js` for better reuse.

### Documentation
- Updated `README.md` with status badges and an accurate repository description.

Closes #4
Closes #5
Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual Now Playing controls: dashboard buttons and API actions to show or dismiss the Now Playing popup (one-shot triggers, 10s auto-hide).
  * Copyable trigger URLs for quick manual actions.

* **Improvements**
  * Smart song-change detection to avoid duplicate Now Playing notifications.
  * Animated queue transitions and motion-enabled Now Playing popup for smoother visuals.
  * Visual refresh across themes: updated borders, colors, shadows, and text styling.

* **Chores**
  * Server-side overlay trigger storage with read and write permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->